### PR TITLE
fix compile warning

### DIFF
--- a/pi400.c
+++ b/pi400.c
@@ -43,7 +43,7 @@ bool modprobe_libcomposite() {
 
     if (pid < 0) return false;
     if (pid == 0) {
-        const char* argv[] = {"modprobe", "libcomposite"};
+        char* const argv[] = {"modprobe", "libcomposite"};
         execv("/usr/sbin/modprobe", argv);
         exit(0);
     }


### PR DESCRIPTION
This fixes the following compile warning:                                                                                                                                         
                                                                                                                                                                                              
```                                                                                                                                                                                           
pi400kb/pi400.c: In function ‘modprobe_libcomposite’:                                                                                                                                         
pi400kb/pi400.c:82:37: warning: passing argument 2 of ‘execv’ from incompatible pointer type [-Wincompatible-pointer-types]                                                                   
   82 |         execv("/usr/sbin/modprobe", argv);                                                                                                                                            
      |                                     ^~~~                                                                                                                                              
      |                                     |                                                                                                                                                 
      |                                     const char **                                                                                                                                     
In file included from pi400kb/pi400.c:14:                                                                                                                                                     
/usr/include/unistd.h:563:51: note: expected ‘char * const*’ but argument is of type ‘const char **’                                                                                          
  563 | extern int execv (const char *__path, char *const __argv[])                                                                                                                           
      |                                       ~~~~~~~~~~~~^~~~~~~~                                                                                                                            
```        