### PR TITLE
improve error handling

### DIFF
--- a/pi400.c
+++ b/pi400.c
@@ -174,7 +174,9 @@ void send_empty_hid_reports_both() {
 }
 
 int main(int argc, char *argv[]) {
+#ifndef NO_OUTPUT
     prechecks(argv[0]);
+#endif
 
     modprobe_libcomposite();
 


### PR DESCRIPTION
This adds two new errors:

* "Error: ./pi400 must be run as root"
* "Error: This must be added to /boot/config.txt and the system rebooted:    dtoverlay=dwc2"

Without this error-checking, the beginner user gets some strange errors that don't really correspond to what they need to fix to proceed.