### PR TITLE
Adds the modprobe.service on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ Enable start on boot if it's okay:
 ```
 sudo systemctl enable pi400kb.service
 ```
+After that, run:
+
+```sudo systemctl edit --force --full modprobe.service```
+
+This will create the service to run ```modprobe libcomposite``` on startup.
+From there, copy and paste the contents of the ```modprobe.service``` into the file.
+
+Run ```sudo systemctl start modprobe.service``` and ```sudo systemctl status modprobe.service```.
+
+If everything is working fine, make it enable at start up with:
+
+```sudo systemctl enable modprobe.service```
+
+And voila! Your Pi400 should now function as a keyboard.
+
+```
 
 ## Building & Contributing
 

--- a/modprobe.service
+++ b/modprobe.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Modprobe on start up
+
+[Service]
+ExecStart=/usr/sbin/modprobe libconfig
+User=root   
+Group=root   
+Type=simple
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/modprobe.service
+++ b/modprobe.service
@@ -2,7 +2,7 @@
 Description=Modprobe on start up
 
 [Service]
-ExecStart=/usr/sbin/modprobe libconfig
+ExecStart=/usr/sbin/modprobe libcomposite
 User=root   
 Group=root   
 Type=simple


### PR DESCRIPTION
The actual pi400kb service will not work on start up due to the need for modprobe libconfig to be ran. This creates a service to run on startup which should fix this.