### PR TITLE
Pass through all the devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,6 @@ if(NOT KEYBOARD_PID)
     set(KEYBOARD_PID "0x0007" CACHE STRING "Product ID for keyboard")
 endif()
 
-if(NOT KEYBOARD_DEV)
-    set(KEYBOARD_DEV "/dev/input/by-id/usb-_Raspberry_Pi_Internal_Keyboard-event-kbd" CACHE STRING "Device path for keyboard")
-endif()
-
 
 if(NOT MOUSE_VID)
     set(MOUSE_VID "0x093a" CACHE STRING "Vendor ID for mouse")
@@ -33,10 +29,6 @@ endif()
 
 if(NOT MOUSE_PID)
     set(MOUSE_PID "0x2510" CACHE STRING "Product ID for mouse")
-endif()
-
-if(NOT MOUSE_DEV)
-    set(MOUSE_DEV "/dev/input/by-id/usb-PixArt_USB_Optical_Mouse-event-mouse" CACHE STRING "Device path for mouse")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,6 @@ if(NOT KEYBOARD_PID)
 endif()
 
 
-if(NOT MOUSE_VID)
-    set(MOUSE_VID "0x093a" CACHE STRING "Vendor ID for mouse")
-endif()
-
-if(NOT MOUSE_PID)
-    set(MOUSE_PID "0x2510" CACHE STRING "Product ID for mouse")
-endif()
-
-
 add_library(libusbgx INTERFACE)
 target_sources(libusbgx INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/libusbgx/src/usbg.c
@@ -85,13 +76,8 @@ target_compile_definitions(pi400kb PRIVATE
 
     HOOK_PATH="${HOOK_PATH}"
 
-    MOUSE_VID=${MOUSE_VID}
-    MOUSE_PID=${MOUSE_PID}
-    MOUSE_DEV="${MOUSE_DEV}"
-
     KEYBOARD_VID=${KEYBOARD_VID}
     KEYBOARD_PID=${KEYBOARD_PID}
-    KEYBOARD_DEV="${KEYBOARD_DEV}"
 )
 
 if(NO_OUTPUT)

--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ CMake accepts the following build arguments to customise the VID/PID and device 
 
 * `KEYBOARD_VID` - Keyboard Vendor ID, default: 0x04d9
 * `KEYBOARD_PID` - Keyboard Product ID, default: 0x0007
-* `KEYBOARD_DEV` - Keyboard device path, default: /dev/input/by-id/usb-_Raspberry_Pi_Internal_Keyboard-event-kbd
-* `MOUSE_VID` - Mouse Vendor ID, default: 0x093a
-* `MOUSE_PID` - Mouse Product ID, default: 0x2510
-* `MOUSE_DEV` - Mouse device path, default: /dev/input/by-id/usb-PixArt_USB_Optical_Mouse-event-mouse
 
 Supply these arguments when configuring with CMake, eg:
 

--- a/gadget-hid.c
+++ b/gadget-hid.c
@@ -40,7 +40,10 @@ int initUSB(struct HIDDevice *devices) {
 
     usbg_ret = usbg_init("/sys/kernel/config", &s);
     if (usbg_ret != USBG_SUCCESS)
+    {
         print_usbg_error("on usbg init", usbg_ret);
+        return usbg_ret;
+    }
 
     // check for existing gadget
     usbg_gadget *ex_gadget = usbg_get_gadget(s, "g1");
@@ -57,12 +60,14 @@ int initUSB(struct HIDDevice *devices) {
         
         usbg_cleanup(s);
         s = NULL;
+        return usbg_ret;
     }
 
     usbg_ret = usbg_create_config(g, 1, "config", NULL, &c_strs, &c);
     if (usbg_ret != USBG_SUCCESS) {
         print_usbg_error("creating config", usbg_ret);
         cleanupUSB();
+        return usbg_ret;
     }
 
     int i = 0;
@@ -87,6 +92,7 @@ int initUSB(struct HIDDevice *devices) {
         if (usbg_ret != USBG_SUCCESS) {
             print_usbg_error("creating function: USBG_F_HID", usbg_ret);
             cleanupUSB();
+            return usbg_ret;
         }
 
         // add func
@@ -94,6 +100,7 @@ int initUSB(struct HIDDevice *devices) {
         if (usbg_ret != USBG_SUCCESS) {
             print_usbg_error("adding function", usbg_ret);
             cleanupUSB();
+            return usbg_ret;
         }
     }
 
@@ -101,6 +108,7 @@ int initUSB(struct HIDDevice *devices) {
     if (usbg_ret != USBG_SUCCESS) {
         print_usbg_error("enabling gadget", usbg_ret);
         cleanupUSB();
+        return usbg_ret;
     }
 
     return usbg_ret;

--- a/gadget-hid.c
+++ b/gadget-hid.c
@@ -10,79 +10,12 @@ usbg_gadget *g;
 usbg_config *c;
 usbg_function *f_hid_keyboard, *f_hid_mouse;
 
-static char keyboard_report_desc[] = {
-    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
-    0x09, 0x06,        // Usage (Keyboard)
-    0xA1, 0x01,        // Collection (Application)
-    0x85, 0x01,        //   Report ID (1)
-    0x05, 0x07,        //   Usage Page (Kbrd/Keypad)
-    0x19, 0xE0,        //   Usage Minimum (0xE0)
-    0x29, 0xE7,        //   Usage Maximum (0xE7)
-    0x15, 0x00,        //   Logical Minimum (0)
-    0x25, 0x01,        //   Logical Maximum (1)
-    0x75, 0x01,        //   Report Size (1)
-    0x95, 0x08,        //   Report Count (8)
-    0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
-    0x95, 0x01,        //   Report Count (1)
-    0x75, 0x08,        //   Report Size (8)
-    0x81, 0x01,        //   Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
-    0x95, 0x03,        //   Report Count (3)
-    0x75, 0x01,        //   Report Size (1)
-    0x05, 0x08,        //   Usage Page (LEDs)
-    0x19, 0x01,        //   Usage Minimum (Num Lock)
-    0x29, 0x03,        //   Usage Maximum (Scroll Lock)
-    0x91, 0x02,        //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x95, 0x05,        //   Report Count (5)
-    0x75, 0x01,        //   Report Size (1)
-    0x91, 0x01,        //   Output (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
-    0x95, 0x06,        //   Report Count (6)
-    0x75, 0x08,        //   Report Size (8)
-    0x15, 0x00,        //   Logical Minimum (0)
-    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
-    0x05, 0x07,        //   Usage Page (Kbrd/Keypad)
-    0x19, 0x00,        //   Usage Minimum (0x00)
-    0x2A, 0xFF, 0x00,  //   Usage Maximum (0xFF)
-    0x81, 0x00,        //   Input (Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
-    0xC0,              // End Collection
-};
-
-static char mouse_report_desc[] = {
-    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
-    0x09, 0x02,        // Usage (Mouse)
-    0xA1, 0x01,        // Collection (Application)
-    0x85, 0x02,        //   Report ID (2)
-    0x09, 0x01,        //   Usage (Pointer)
-    0xA1, 0x00,        //   Collection (Physical)
-    0x05, 0x09,        //     Usage Page (Button)
-    0x19, 0x01,        //     Usage Minimum (0x01)
-    0x29, 0x03,        //     Usage Maximum (0x03)
-    0x15, 0x00,        //     Logical Minimum (0)
-    0x25, 0x01,        //     Logical Maximum (1)
-    0x75, 0x01,        //     Report Size (1)
-    0x95, 0x03,        //     Report Count (3)
-    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
-    0x75, 0x05,        //     Report Size (5)
-    0x95, 0x01,        //     Report Count (1)
-    0x81, 0x01,        //     Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
-    0x05, 0x01,        //     Usage Page (Generic Desktop Ctrls)
-    0x09, 0x30,        //     Usage (X)
-    0x09, 0x31,        //     Usage (Y)
-    0x09, 0x38,        //     Usage (Wheel)
-    0x15, 0x81,        //     Logical Minimum (-127)
-    0x25, 0x7F,        //     Logical Maximum (127)
-    0x75, 0x08,        //     Report Size (8)
-    0x95, 0x03,        //     Report Count (3)
-    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
-    0xC0,              //   End Collection
-    0xC0,              // End Collection
-};
-
 static void print_usbg_error(const char *str, int usbg_ret) {
     fprintf(stderr, "Error %s: %s : %s\n", str, usbg_error_name(usbg_ret),
             usbg_strerror(usbg_ret));
 }
 
-int initUSB() {
+int initUSB(struct hidraw_report_descriptor *keyboard_desc, struct hidraw_report_descriptor *mouse_desc) {
     int usbg_ret = -EINVAL;
 
     struct usbg_gadget_attrs g_attrs = {
@@ -109,8 +42,8 @@ int initUSB() {
     struct usbg_f_hid_attrs f_keyboard_attrs = {
         .protocol = 1,
         .report_desc = {
-            .desc = keyboard_report_desc,
-            .len = sizeof(keyboard_report_desc),
+            .desc = keyboard_desc->value,
+            .len = keyboard_desc->size,
         },
         .report_length = 16,
         .subclass = 0,
@@ -119,8 +52,8 @@ int initUSB() {
     struct usbg_f_hid_attrs f_mouse_attrs = {
         .protocol = 1,
         .report_desc = {
-            .desc = mouse_report_desc,
-            .len = sizeof(mouse_report_desc),
+            .desc = mouse_desc->value,
+            .len = mouse_desc->size,
         },
         .report_length = 16,
         .subclass = 0,

--- a/gadget-hid.c
+++ b/gadget-hid.c
@@ -75,6 +75,11 @@ static char report_desc[] = {
     0xC0,              // End Collection
 };
 
+static void print_usbg_error(const char *str, int usbg_ret) {
+    fprintf(stderr, "Error %s: %s : %s\n", str, usbg_error_name(usbg_ret),
+            usbg_strerror(usbg_ret));
+}
+
 int initUSB() {
     int usbg_ret = -EINVAL;
 
@@ -110,11 +115,8 @@ int initUSB() {
     };
 
     usbg_ret = usbg_init("/sys/kernel/config", &s);
-    if (usbg_ret != USBG_SUCCESS) {
-        fprintf(stderr, "Error on usbg init\n");
-        fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
-                usbg_strerror(usbg_ret));
-    }
+    if (usbg_ret != USBG_SUCCESS)
+        print_usbg_error("on usbg init", usbg_ret);
 
     // check for existing gadget
     usbg_gadget *ex_gadget = usbg_get_gadget(s, "g1");
@@ -127,9 +129,7 @@ int initUSB() {
 
     usbg_ret = usbg_create_gadget(s, "g1", &g_attrs, &g_strs, &g);
     if (usbg_ret != USBG_SUCCESS) {
-        fprintf(stderr, "Error creating gadget\n");
-        fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
-                usbg_strerror(usbg_ret));
+        print_usbg_error("creating gadget", usbg_ret);
         
         usbg_cleanup(s);
         s = NULL;
@@ -137,33 +137,25 @@ int initUSB() {
 
     usbg_ret = usbg_create_function(g, USBG_F_HID, "usb0", &f_attrs, &f_hid);
     if (usbg_ret != USBG_SUCCESS) {
-        fprintf(stderr, "Error creating function: USBG_F_HID\n");
-        fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
-                usbg_strerror(usbg_ret));
+        print_usbg_error("creating function: USBG_F_HID", usbg_ret);
         cleanupUSB();
     }
 
     usbg_ret = usbg_create_config(g, 1, "config", NULL, &c_strs, &c);
     if (usbg_ret != USBG_SUCCESS) {
-        fprintf(stderr, "Error creating config\n");
-        fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
-                usbg_strerror(usbg_ret));
+        print_usbg_error("creating config", usbg_ret);
         cleanupUSB();
     }
 
     usbg_ret = usbg_add_config_function(c, "keyboard", f_hid);
     if (usbg_ret != USBG_SUCCESS) {
-        fprintf(stderr, "Error adding function: keyboard\n");
-        fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
-                usbg_strerror(usbg_ret));
+        print_usbg_error("adding function: keyboard", usbg_ret);
         cleanupUSB();
     }
 
     usbg_ret = usbg_enable_gadget(g, DEFAULT_UDC);
     if (usbg_ret != USBG_SUCCESS) {
-        fprintf(stderr, "Error enabling gadget\n");
-        fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
-                usbg_strerror(usbg_ret));
+        print_usbg_error("enabling gadget", usbg_ret);
         cleanupUSB();
     }
 

--- a/gadget-hid.c
+++ b/gadget-hid.c
@@ -117,6 +117,15 @@ int initUSB() {
         goto out1;
     }
 
+    // check for existing gadget
+    usbg_gadget *ex_gadget = usbg_get_gadget(s, "g1");
+
+    if(ex_gadget) {
+        // remove it (assume failed shutdown)
+        usbg_disable_gadget(ex_gadget);
+        usbg_rm_gadget(ex_gadget, USBG_RM_RECURSE);
+    }
+
     usbg_ret = usbg_create_gadget(s, "g1", &g_attrs, &g_strs, &g);
     if (usbg_ret != USBG_SUCCESS) {
         fprintf(stderr, "Error creating gadget\n");

--- a/gadget-hid.h
+++ b/gadget-hid.h
@@ -14,7 +14,6 @@
 #define MOUSE_HID_REPORT_SIZE    4
 
 struct hid_buf {
-    uint8_t report_id;
     unsigned char data[64];
 }  __attribute__ ((aligned (1)));
 

--- a/gadget-hid.h
+++ b/gadget-hid.h
@@ -1,3 +1,4 @@
+#include <linux/hidraw.h>
 #include <linux/usb/ch9.h>
 #include <usbg/usbg.h>
 #include <usbg/function/hid.h>
@@ -17,5 +18,5 @@ struct hid_buf {
     unsigned char data[64];
 }  __attribute__ ((aligned (1)));
 
-int initUSB();
+int initUSB(struct hidraw_report_descriptor *keyboard_desc, struct hidraw_report_descriptor *mouse_desc);
 int cleanupUSB();

--- a/gadget-hid.h
+++ b/gadget-hid.h
@@ -17,5 +17,24 @@ struct hid_buf {
     unsigned char data[64];
 }  __attribute__ ((aligned (1)));
 
-int initUSB(struct hidraw_report_descriptor *keyboard_desc, struct hidraw_report_descriptor *mouse_desc);
+
+struct HIDDevice {
+    int hidraw_fd;
+    int hidraw_index;
+
+    int uinput_fd;
+
+    int output_fd;
+
+    bool is_keyboard;
+
+    int report_size;
+    struct hidraw_report_descriptor report_desc;
+
+    struct hid_buf buf;
+
+    struct HIDDevice *next;
+};
+
+int initUSB(struct HIDDevice *devices);
 int cleanupUSB();

--- a/gadget-hid.h
+++ b/gadget-hid.h
@@ -3,16 +3,6 @@
 #include <usbg/usbg.h>
 #include <usbg/function/hid.h>
 
-//#define KEYBOARD_VID             0x04d9
-//#define KEYBOARD_PID             0x0007
-//#define KEYBOARD_DEV             "/dev/input/by-id/usb-_Raspberry_Pi_Internal_Keyboard-event-kbd"
-#define KEYBOARD_HID_REPORT_SIZE 8
-
-//#define MOUSE_VID                0x093a
-//#define MOUSE_PID                0x2510
-//#define MOUSE_DEV                "/dev/input/by-id/usb-PixArt_USB_Optical_Mouse-event-mouse"
-#define MOUSE_HID_REPORT_SIZE    4
-
 struct hid_buf {
     unsigned char data[64];
 }  __attribute__ ((aligned (1)));

--- a/pi400.c
+++ b/pi400.c
@@ -71,8 +71,11 @@ int find_hidraw_device(char *device_type, int16_t vid, int16_t pid) {
 
         ret = ioctl(fd, HIDIOCGRAWINFO, &hidinfo);
 
-        if(hidinfo.vendor == vid && hidinfo.product == pid) {
-            printf("Found %s at: %s\n", device_type, path);
+        if(ret == 0 && hidinfo.vendor == vid && hidinfo.product == pid) {
+            char name[256] = {0};
+            ioctl(fd, HIDIOCGRAWNAME(sizeof(name)), &name);
+
+            printf("Found %s at: %s (%s)\n", device_type, path, name);
             return fd;
         }
 

--- a/pi400.c
+++ b/pi400.c
@@ -380,11 +380,14 @@ int main() {
     ungrab_all();
     send_empty_hid_reports_all();
 
-    cleanup_hid_device(keyboard_device);
-    cleanup_hid_device(mouse_device);
+    for(struct HIDDevice *d = devices; d;) {
+        struct HIDDevice *next = d->next;
 
-    free(keyboard_device);
-    free(mouse_device);
+        cleanup_hid_device(d);
+        free(d);
+
+        d = next;
+    }
 
 #ifndef NO_OUTPUT
     printf("Cleanup USB\n");

--- a/pi400.c
+++ b/pi400.c
@@ -287,9 +287,6 @@ int main() {
     init_hid_device(&keyboard_device);
     init_hid_device(&mouse_device);
 
-    keyboard_device.buf.report_id = 1;
-    mouse_device.buf.report_id = 2;
-
     int found_devices = 0;
 
     if(find_hidraw_device(&keyboard_device, "keyboard", KEYBOARD_VID, KEYBOARD_PID))

--- a/pi400.c
+++ b/pi400.c
@@ -25,24 +25,6 @@ volatile int grabbed = 0;
 
 int ret;
 
-struct HIDDevice {
-    int hidraw_fd;
-    int hidraw_index;
-
-    int uinput_fd;
-
-    int output_fd;
-
-    bool is_keyboard;
-
-    int report_size;
-    struct hidraw_report_descriptor report_desc;
-
-    struct hid_buf buf;
-
-    struct HIDDevice *next;
-};
-
 static struct HIDDevice *devices = NULL;
 static int num_devices = 0;
 
@@ -320,7 +302,7 @@ int main() {
     }
 
 #ifndef NO_OUTPUT
-    ret = initUSB(&keyboard_device->report_desc, &mouse_device->report_desc);
+    ret = initUSB(devices);
     if(ret != USBG_SUCCESS && ret != USBG_ERROR_EXIST) {
         return 1;
     }

--- a/pi400.c
+++ b/pi400.c
@@ -313,8 +313,14 @@ int main() {
 
 #ifndef NO_OUTPUT
     // making some assumptions here...
-    if(!open_output(keyboard_device, "/dev/hidg0") || !open_output(mouse_device, "/dev/hidg1"))
-        return 1;
+    int i = 0;
+    char str[20];
+    for(struct HIDDevice *d = devices; d; d = d->next, i++) {
+        snprintf(str, sizeof(str), "/dev/hidg%i", i);
+        if(!open_output(d, str))
+            return 1;
+    }
+
 #endif
 
     printf("Running...\n");
@@ -323,7 +329,7 @@ int main() {
 
     struct pollfd *poll_fds = malloc(sizeof(struct pollfd) * num_devices);
 
-    int i = 0;
+    i = 0;
     for(struct HIDDevice *d = devices; d; d = d->next, i++) {
         poll_fds[i].fd = d->hidraw_fd;
         poll_fds[i].events = POLLIN;
@@ -333,7 +339,7 @@ int main() {
         poll(poll_fds, num_devices, -1);
         // should check which fds are ready...
 
-        for(struct HIDDevice *d = devices; d; d = d->next, i++) {
+        for(struct HIDDevice *d = devices; d; d = d->next) {
             if(d->hidraw_fd == -1)
                 continue;
 

--- a/pi400.c
+++ b/pi400.c
@@ -50,7 +50,10 @@ bool modprobe_libcomposite() {
     waitpid(pid, NULL, 0);
 }
 
-bool trigger_hook() {
+void trigger_hook() {
+    if(access(HOOK_PATH, F_OK) != 0)
+        return;
+
     char buf[4096];
     snprintf(buf, sizeof(buf), "%s %u", HOOK_PATH, grabbed ? 1u : 0u);
     system(buf);

--- a/pi400.c
+++ b/pi400.c
@@ -35,6 +35,8 @@ struct HIDDevice {
 struct HIDDevice keyboard_device;
 struct HIDDevice mouse_device;
 
+void ungrab(int fd);
+
 void signal_handler(int dummy) {
     running = 0;
 }
@@ -63,6 +65,16 @@ void trigger_hook() {
 }
 
 static void init_hid_device(struct HIDDevice *dev) {
+    dev->hidraw_fd = -1;
+    dev->uinput_fd = -1;
+}
+
+static void cleanup_hid_device(struct HIDDevice *dev) {
+    if(dev->hidraw_fd != -1)
+        close(dev->hidraw_fd);
+    if(dev->uinput_fd != -1)
+        ungrab(dev->uinput_fd);
+
     dev->hidraw_fd = -1;
     dev->uinput_fd = -1;
 }
@@ -274,6 +286,9 @@ int main() {
 
     ungrab_both();
     send_empty_hid_reports_both();
+
+    cleanup_hid_device(&keyboard_device);
+    cleanup_hid_device(&mouse_device);
 
 #ifndef NO_OUTPUT
     printf("Cleanup USB\n");


### PR DESCRIPTION
... well, up to four because of kernel limit on HID functions.

Ended up looking at this more than I intended to, so there are a bunch of changes here.

- Some improvements to error handling to not end up with a broken gadget if you don't follow the instructions properly. (Though I did break it a bit until the end...)
- Some refactoring to avoid hardcoding the device paths. Not sure how correct this is, but it worked.
- More refactoring to split keyboard/mouse into separate functions and pass through the report descriptors. (Theoretically meaning any mouse would work, but the one I had lying around happens to be identical to the pi one)
- Even more refactoring to build a list of all devices and pass them through. As a nice bonus, this works for forwarding bluetooth devices. (Tested with a switch pro controller, which mostly worked)

Currently this introduces a few new issues:
- Completely fails to start if there are more than four hidraw devices.
- Keyboard has two hidraw devices for some reason, don't know what the other one is for considering it worked fine passing through the first one. This does not help with the previous limit.
- Some devices result in a lot of spam from printing the reports
- Passed through game controllers get messed up mappings, probably because the host can't identify them correctly.
- Also, it's only lightly tested.